### PR TITLE
Fix for rounded corners in submenu when only one child

### DIFF
--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -39,6 +39,12 @@
 	border-radius: 0px 0px 6px 6px;
 }
 
+.dropdown-submenu > .dropdown-menu li:only-child a {
+  -webkit-border-radius: 0px 6px 6px 6px;
+	-moz-border-radius: 0px 6px 6px 6px;	
+	border-radius: 0px 6px 6px 6px;
+}
+
 code {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
This fixes rounded corners in submenu items when there is only one child.