### PR TITLE
change CDN links to jsDelivr

### DIFF
--- a/docs/get-started/60-second-setup.md
+++ b/docs/get-started/60-second-setup.md
@@ -11,8 +11,8 @@ Create a file called `index.html` and paste in the following (or just open the p
   <meta charset='utf-8'>
   <title>Hello World</title>
 
-  <!-- The latest release of Ractive can always be found at https://unpkg.com/ractive -->
-  <script src='https://unpkg.com/ractive'></script>
+  <!-- The latest release of Ractive can always be found at https://cdn.jsdelivr.net/npm/ractive -->
+  <script src='https://cdn.jsdelivr.net/npm/ractive'></script>
 </head>
 <body>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,8 @@ Welcome! These pages aim to provide all the information you need to master Racti
 Ractive is available via the following channels:
 
 ```
-// unpkg
-https://unpkg.com/ractive
+// jsDelivr
+https://cdn.jsdelivr.net/npm/ractive
 
 // CDNjs
 https://cdnjs.com/libraries/ractive


### PR DESCRIPTION
[jsDelivr](https://github.com/jsdelivr/jsdelivr) recently added a npm proxy and now it's basically unpkg with extra features and much better stability