### PR TITLE
Fix broken link to the Parse Object documentation

### DIFF
--- a/docs/api/initialization-options.md
+++ b/docs/api/initialization-options.md
@@ -928,7 +928,7 @@ Alias for [`el`](#el).
 
 `(string|array|object|function)`
 
-The [template](../concepts/templates.md#overview) to use. Must either be a CSS selector string pointing to an element on the page containing the template, an HTML string, an object resulting from [`Ractive.parse()`](/api/static-methods.md#ractiveparse) or a function that returns any of the previous options. The function form accepts processed [`data`](#data) and a [Parse Object](./parse.md).
+The [template](../concepts/templates.md#overview) to use. Must either be a CSS selector string pointing to an element on the page containing the template, an HTML string, an object resulting from [`Ractive.parse()`](/api/static-methods.md#ractiveparse) or a function that returns any of the previous options. The function form accepts processed [`data`](#data) and a [Parse Object](/api/parse-object.md).
 
 ```js
 // Selector

--- a/docs/api/initialization-options.md
+++ b/docs/api/initialization-options.md
@@ -928,7 +928,7 @@ Alias for [`el`](#el).
 
 `(string|array|object|function)`
 
-The [template](../concepts/templates.md#overview) to use. Must either be a CSS selector string pointing to an element on the page containing the template, an HTML string, an object resulting from [`Ractive.parse()`](/api/static-methods.md#ractiveparse) or a function that returns any of the previous options. The function form accepts processed [`data`](#data) and a [Parse Object](/api/parse-object.md).
+The [template](../concepts/templates.md#overview) to use. Must either be a CSS selector string pointing to an element on the page containing the template, an HTML string, an object resulting from [`Ractive.parse()`](/api/static-methods.md#ractiveparse) or a function that returns any of the previous options. The function form accepts processed [`data`](#data) and a [Parse Object](./parse-object.md).
 
 ```js
 // Selector


### PR DESCRIPTION
~I chose to use the syntax from just below this change (the `ractive.reset()` link), because I feel like absolute paths are more predictable than relative paths (e.g. the `template` link just above).~

~That said, I can change this as necessary.~

Should meet repo standards about relative paths. It was just a filename issue.