### PR TITLE
Improve ractive.set documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2773,9 +2773,12 @@ Escapes the given key so that it can be concatenated with a keypath string.
 
 **Examples**
 
-```js
-Ractive.escapeKey('foo.bar'); // foo\.bar
-```
+* Simple example
+
+        Ractive.escapeKey('foo.bar'); // 'foo\\.bar'
+        
+
+* [Playground example](https://ractive.js.org/playground/?env=docs#N4IgFiBcoE5SBTAJgcwSAvgGhAF3gDxICWAbgATFIC8AOiAPYCuuADi-QHwED0JpnWgDsCAZwDGMYq1yUa9YkPa565XAE9WCOngQAPXDxgBDcbjIIuw2rgKtBKlUJs2CAIxa4GQ8t4C04gA2xOIA1jriYMZCaACqMIFcAMJRMQjksQBKADK8HrheQoLOju6e3r5CAcFhEalxCQBMyfXpWdnkABQA7sS4YOSZpuakCAB0CBLGWp0AlLN55UXWtjz2K3ac5Cs2TAm+AGbbIMZjAFasKKrEopDk7pzAwJQAtigA2gDkpxconwC6Yz2gXIGAweS2GzWxV4EikMk4IBwongQgQ3UGwwsnWAK1wxhgaFwd0+AGJmGwWJ8sHiEC9WIFjLgECTSYplNSVt5oDtcJFog1AncDkwhGZiN45riSi4CmAbmNRAhcJ1PsQ3mNjLRtbRzpcgQlqcceC91Dw0d01kywHqriBZgBuXnYXn8tLxQKNYWi8WS2bS2U2U2hBDqcjUcjfW2fJ0yxz9BVKlVqjWfcgAakx4tGEymWgA0qHOsHQ7MM5GDYEjfQeP0EDwGHWYFb+rb6I7nSsXSUkEzjHcA451SgB7ybFHfp9R3HZcC7jXWNbawweD9LvQx7gMJ2StuZUIMLNMEA)
 
 ## Ractive.extend()
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4155,7 +4155,12 @@ When setting an array value, ractive will reuse the existing DOM nodes for the n
 
 **Arguments**
 
-- `keypath (string)`: The keypath of the data we're changing, e.g. `user` or `user.name` or `user.friends[1]` or `users.*.status`.
+- `keypath (string)`: The keypath of the data we're changing, e.g.
+    * `user`
+    * `user.name`
+    * `user.friends[1]` or `user.friends.1`
+    * `users.*.status`
+    * `images.aaa\\.jpg.url`.
 - `value (any)`: The value we're changing it to. Can be a primitive or an object (or array), in which case dependants of *downstream keypaths* will also be re-rendered (if they have changed).
 - `map (Object)`: A map of `keypath: value` pairs, as above.
 - `[options] Object`:
@@ -4183,6 +4188,10 @@ ractive.on('selectAll', function(){
 	ractive.set('items.*.selected', true);
 })
 ```
+
+**See Also**
+
+* [`Ractive.escapeKey()`](#ractiveescapekey)
 
 ## ractive.shift()
 


### PR DESCRIPTION
It was unclear that how we set a keypath which includes a dot in the key name, like in  https://github.com/ractivejs/ractive/issues/3072

This PR aims to make it clear. 