### PR TITLE
Search modal - fix result link close

### DIFF
--- a/docs/static/js/index.js
+++ b/docs/static/js/index.js
@@ -115,4 +115,15 @@ $(function () {
     });
   });
 
+  // simplified modal interface to make mkdocs search plugin works correctly in all search scenario
+  $.fn.modal = function(action) {
+    switch (action) {
+      case 'hide':
+        $('#search-state').prop('checked', false);
+        break;
+
+      default:
+        $('#search-state').prop('checked', true);
+    }
+  };
 });

--- a/theme/base.html
+++ b/theme/base.html
@@ -72,7 +72,7 @@
   {% block mobile_toc %}{% endblock %}
   {% include "nav-main.html" %}
 
-  <div class="search-modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-labelledby="Search Modal" aria-hidden="true">
+  <div class="search-modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-label="Search Modal" aria-hidden="true">
     <label class="close-search" for="search-state" aria-role="close">&times;</label>
     <input type="text" class="search-field" placeholder="Search..." id="mkdocs-search-query">
     <div id="mkdocs-search-results"></div>


### PR DESCRIPTION
Fix  for #146:
Added simplified modal interface to make mkdocs search plugin works correctly.
It simply change attribute "checked" beacuse search modal is handled via CSS.

Accessibility little fix
Change `aria-labbledby` to `aria-label`