### PR TITLE
Added Ralma

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -45,6 +45,7 @@ Encapsulate functionality behind the guise of a custom element.
 - [Ractive-Require](https://github.com/XavierBoubert/ractive-require)
 - [CodeMirror](http://dagnelies.github.io/ractive-codemirror/)
 - [Bootstrap](http://dagnelies.github.io/ractive-bootstrap/)
+- [Ralma](http://aldi.github.io/ralma/) - Ractive Components for Bulma CSS Framework.
 - [Datatable](https://github.com/JonDum/ractive-datatable)
 - [Foundation](http://ractive-foundation.github.io/ractive-foundation)
 - [Select](https://github.com/JonDum/ractive-select) - A `<select>` replacement component.


### PR DESCRIPTION
Ralma provides helper shortcuts for most Bulma widgets. The goal of this plugin is to help you get started quickly and reduce the overly verbose code that Bulma tends to produce. It does not attempt to cover everything in Bulma, but rather offer the most common elements as shortcuts. Sometimes, when you want something more specific or fancy, you can still use the original Bulma markup.