### PR TITLE
computed compact syntax no longer uses ${...}

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2195,7 +2195,7 @@ A map of computed properties where the key is the name of the computed property 
 // Imagine a square...
 computed: {
   // Computed property expression
-  diagonal: '${side} * Math.sqrt(2)',
+  diagonal: 'side * Math.sqrt(2)',
 
   // A function
   perimeter () {


### PR DESCRIPTION
https://github.com/ractivejs/ractive/pull/3141 removed interpolation tags `${...}` from computed property expressions (which used to be called the "computed compact syntax")